### PR TITLE
Fix publish workflow to target only Repsy repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Publish to Repsy
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: ${{ matrix.target }}:publish -x ${{ matrix.target }}:jvmTest --refresh-dependencies
+          arguments: ${{ matrix.target }}:publishAllPublicationsToMavenRepository -x ${{ matrix.target }}:jvmTest --refresh-dependencies
         env:
           USERNAME: ${{ secrets.REPSY_USERNAME }}
           PASSWORD: ${{ secrets.REPSY_PASSWORD }}


### PR DESCRIPTION
Change publish task from 'publish' to 'publishAllPublicationsToMavenRepository' to avoid attempting to publish to Sonatype without credentials. The nexus-publish plugin registers a Sonatype repository that requires separate credentials not provided in the workflow.