### PR TITLE
Drop redundant build step from SNAPSHOT publish workflow

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -23,15 +23,11 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Build with Gradle
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: build -x check
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Publish to Repsy
-      uses: gradle/actions/setup-gradle@v3
-      with:
-        arguments: publishAllPublicationsToMavenRepository -x check
+      run: ./gradlew publishAllPublicationsToMavenRepository -x check
       env:
         USERNAME: ${{ secrets.REPSY_USERNAME }}
         PASSWORD: ${{ secrets.REPSY_PASSWORD }}


### PR DESCRIPTION
The build step ran the :all module's native framework linking, which the Maven publish does not depend on. Publish only emits klibs; frameworks are handled by separate workflows. Also modernize to setup-gradle@v4.